### PR TITLE
feat: add Java SDK users beta kickoff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Run Maven tests
+        run: mvn -B test

--- a/README.md
+++ b/README.md
@@ -4,4 +4,49 @@ Official Java SDK for Axme APIs and workflows.
 
 ## Status
 
-Repository bootstrap in progress.
+Beta parity kickoff in progress.
+
+## Quickstart
+
+```java
+import dev.axme.sdk.AxmeClient;
+import dev.axme.sdk.AxmeClientConfig;
+import dev.axme.sdk.RequestOptions;
+import java.util.Map;
+
+public class Quickstart {
+  public static void main(String[] args) throws Exception {
+    AxmeClient client = new AxmeClient(new AxmeClientConfig("https://gateway.example.com", "YOUR_API_KEY"));
+
+    Map<String, Object> registered =
+        client.registerNick(
+            Map.of("nick", "@partner.user", "display_name", "Partner User"),
+            new RequestOptions("nick-register-001", null));
+
+    Map<String, Object> check = client.checkNick("@partner.user", RequestOptions.none());
+
+    Map<String, Object> renamed =
+        client.renameNick(
+            Map.of("owner_agent", registered.get("owner_agent"), "nick", "@partner.new"),
+            new RequestOptions("nick-rename-001", null));
+
+    Map<String, Object> profile =
+        client.getUserProfile((String) registered.get("owner_agent"), RequestOptions.none());
+
+    Map<String, Object> updated =
+        client.updateUserProfile(
+            Map.of("owner_agent", profile.get("owner_agent"), "display_name", "Partner User Updated"),
+            new RequestOptions("profile-update-001", null));
+
+    System.out.println(check);
+    System.out.println(renamed);
+    System.out.println(updated);
+  }
+}
+```
+
+## Development
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dev.axme</groupId>
+  <artifactId>axme-sdk-java</artifactId>
+  <version>0.1.0</version>
+  <name>axme-sdk-java</name>
+  <description>Official Java SDK for Axme APIs and workflows.</description>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit.version>5.10.2</junit.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>4.12.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/dev/axme/sdk/AxmeClient.java
+++ b/src/main/java/dev/axme/sdk/AxmeClient.java
@@ -1,0 +1,137 @@
+package dev.axme.sdk;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class AxmeClient {
+  private final String baseUrl;
+  private final String apiKey;
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public AxmeClient(AxmeClientConfig config) {
+    this(config, HttpClient.newHttpClient());
+  }
+
+  public AxmeClient(AxmeClientConfig config, HttpClient httpClient) {
+    this.baseUrl = config.getBaseUrl();
+    this.apiKey = config.getApiKey();
+    this.httpClient = httpClient;
+  }
+
+  public Map<String, Object> registerNick(Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    return requestJson("POST", "/v1/users/register-nick", Map.of(), payload, normalizeOptions(options));
+  }
+
+  public Map<String, Object> checkNick(String nick, RequestOptions options)
+      throws IOException, InterruptedException {
+    return requestJson("GET", "/v1/users/check-nick", Map.of("nick", nick), null, normalizeOptions(options));
+  }
+
+  public Map<String, Object> renameNick(Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    return requestJson("POST", "/v1/users/rename-nick", Map.of(), payload, normalizeOptions(options));
+  }
+
+  public Map<String, Object> getUserProfile(String ownerAgent, RequestOptions options)
+      throws IOException, InterruptedException {
+    return requestJson(
+        "GET",
+        "/v1/users/profile",
+        Map.of("owner_agent", ownerAgent),
+        null,
+        normalizeOptions(options));
+  }
+
+  public Map<String, Object> updateUserProfile(Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    return requestJson("POST", "/v1/users/profile/update", Map.of(), payload, normalizeOptions(options));
+  }
+
+  private Map<String, Object> requestJson(
+      String method,
+      String path,
+      Map<String, String> query,
+      Map<String, Object> payload,
+      RequestOptions options)
+      throws IOException, InterruptedException {
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(buildUrl(path, query)))
+            .method(method, payload == null ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
+            .header("Authorization", "Bearer " + apiKey)
+            .header("Accept", "application/json");
+
+    if (payload != null) {
+      builder.header("Content-Type", "application/json");
+    }
+    if (!isBlank(options.getIdempotencyKey())) {
+      builder.header("Idempotency-Key", options.getIdempotencyKey());
+    }
+    if (!isBlank(options.getTraceId())) {
+      builder.header("X-Trace-Id", options.getTraceId());
+    }
+
+    HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      throw new AxmeHttpException(response.statusCode(), response.body());
+    }
+    if (response.body() == null || response.body().trim().isEmpty()) {
+      return Map.of();
+    }
+
+    return objectMapper.readValue(response.body(), new TypeReference<Map<String, Object>>() {});
+  }
+
+  private String buildUrl(String path, Map<String, String> query) {
+    if (query == null || query.isEmpty()) {
+      return baseUrl + path;
+    }
+
+    Map<String, String> filtered = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : query.entrySet()) {
+      if (!isBlank(entry.getValue())) {
+        filtered.put(entry.getKey(), entry.getValue());
+      }
+    }
+    if (filtered.isEmpty()) {
+      return baseUrl + path;
+    }
+
+    StringBuilder builder = new StringBuilder(baseUrl).append(path).append("?");
+    boolean first = true;
+    for (Map.Entry<String, String> entry : filtered.entrySet()) {
+      if (!first) {
+        builder.append("&");
+      }
+      first = false;
+      builder
+          .append(urlEncode(entry.getKey()))
+          .append("=")
+          .append(urlEncode(entry.getValue()));
+    }
+    return builder.toString();
+  }
+
+  private static String urlEncode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  private static RequestOptions normalizeOptions(RequestOptions options) {
+    return options == null ? RequestOptions.none() : options;
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+}

--- a/src/main/java/dev/axme/sdk/AxmeClientConfig.java
+++ b/src/main/java/dev/axme/sdk/AxmeClientConfig.java
@@ -1,0 +1,32 @@
+package dev.axme.sdk;
+
+public final class AxmeClientConfig {
+  private final String baseUrl;
+  private final String apiKey;
+
+  public AxmeClientConfig(String baseUrl, String apiKey) {
+    if (baseUrl == null || baseUrl.trim().isEmpty()) {
+      throw new IllegalArgumentException("baseUrl is required");
+    }
+    if (apiKey == null || apiKey.trim().isEmpty()) {
+      throw new IllegalArgumentException("apiKey is required");
+    }
+    this.baseUrl = trimTrailingSlash(baseUrl.trim());
+    this.apiKey = apiKey.trim();
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  private static String trimTrailingSlash(String value) {
+    if (value.endsWith("/")) {
+      return value.substring(0, value.length() - 1);
+    }
+    return value;
+  }
+}

--- a/src/main/java/dev/axme/sdk/AxmeHttpException.java
+++ b/src/main/java/dev/axme/sdk/AxmeHttpException.java
@@ -1,0 +1,20 @@
+package dev.axme.sdk;
+
+public final class AxmeHttpException extends RuntimeException {
+  private final int statusCode;
+  private final String responseBody;
+
+  public AxmeHttpException(int statusCode, String responseBody) {
+    super("axme request failed with status " + statusCode);
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  public String getResponseBody() {
+    return responseBody;
+  }
+}

--- a/src/main/java/dev/axme/sdk/RequestOptions.java
+++ b/src/main/java/dev/axme/sdk/RequestOptions.java
@@ -1,0 +1,27 @@
+package dev.axme.sdk;
+
+public final class RequestOptions {
+  private final String idempotencyKey;
+  private final String traceId;
+
+  public RequestOptions() {
+    this(null, null);
+  }
+
+  public RequestOptions(String idempotencyKey, String traceId) {
+    this.idempotencyKey = idempotencyKey;
+    this.traceId = traceId;
+  }
+
+  public String getIdempotencyKey() {
+    return idempotencyKey;
+  }
+
+  public String getTraceId() {
+    return traceId;
+  }
+
+  public static RequestOptions none() {
+    return new RequestOptions();
+  }
+}

--- a/src/test/java/dev/axme/sdk/AxmeClientTest.java
+++ b/src/test/java/dev/axme/sdk/AxmeClientTest.java
@@ -1,0 +1,113 @@
+package dev.axme.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AxmeClientTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private MockWebServer server;
+  private AxmeClient client;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = new MockWebServer();
+    server.start();
+    client = new AxmeClient(new AxmeClientConfig(server.url("/").toString(), "token"));
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  @Test
+  void registerNickSendsPayloadAndHeaders() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"owner_agent\":\"agent://user/1\"}"));
+
+    Map<String, Object> response =
+        client.registerNick(
+            Map.of("nick", "@partner.user", "display_name", "Partner User"),
+            new RequestOptions("register-1", null));
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("POST", request.getMethod());
+    assertEquals("/v1/users/register-nick", request.getPath());
+    assertEquals("Bearer token", request.getHeader("Authorization"));
+    assertEquals("register-1", request.getHeader("Idempotency-Key"));
+
+    Map<String, Object> body =
+        objectMapper.readValue(request.getBody().readUtf8(), new TypeReference<Map<String, Object>>() {});
+    assertEquals("@partner.user", body.get("nick"));
+    assertTrue((Boolean) response.get("ok"));
+  }
+
+  @Test
+  void checkNickSendsQueryParameter() throws Exception {
+    server.enqueue(
+        new MockResponse()
+            .setResponseCode(200)
+            .setBody(
+                "{\"ok\":true,\"nick\":\"@partner.user\",\"normalized_nick\":\"partner.user\",\"public_address\":\"partner.user@ax\",\"available\":true}"));
+
+    Map<String, Object> response = client.checkNick("@partner.user", RequestOptions.none());
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("GET", request.getMethod());
+    assertEquals("/v1/users/check-nick?nick=%40partner.user", request.getPath());
+    assertTrue((Boolean) response.get("available"));
+  }
+
+  @Test
+  void renameNickSendsPayloadAndIdempotency() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"nick\":\"@partner.new\"}"));
+
+    Map<String, Object> response =
+        client.renameNick(
+            Map.of("owner_agent", "agent://user/1", "nick", "@partner.new"),
+            new RequestOptions("rename-1", null));
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("POST", request.getMethod());
+    assertEquals("/v1/users/rename-nick", request.getPath());
+    assertEquals("rename-1", request.getHeader("Idempotency-Key"));
+    assertEquals("@partner.new", response.get("nick"));
+  }
+
+  @Test
+  void getUserProfileSendsOwnerAgentQuery() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"owner_agent\":\"agent://user/1\"}"));
+
+    Map<String, Object> response = client.getUserProfile("agent://user/1", RequestOptions.none());
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("GET", request.getMethod());
+    assertEquals("/v1/users/profile?owner_agent=agent%3A%2F%2Fuser%2F1", request.getPath());
+    assertEquals("agent://user/1", response.get("owner_agent"));
+  }
+
+  @Test
+  void updateUserProfileSendsPayloadAndIdempotency() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"display_name\":\"Partner User Updated\"}"));
+
+    Map<String, Object> response =
+        client.updateUserProfile(
+            Map.of("owner_agent", "agent://user/1", "display_name", "Partner User Updated"),
+            new RequestOptions("profile-1", null));
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("POST", request.getMethod());
+    assertEquals("/v1/users/profile/update", request.getPath());
+    assertEquals("profile-1", request.getHeader("Idempotency-Key"));
+    assertEquals("Partner User Updated", response.get("display_name"));
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap Java SDK with users family helpers (`register/check/rename/profile get/update`)
- add request option handling for idempotency and trace headers
- add JUnit + MockWebServer tests and Maven CI workflow

## Test plan
- [ ] Local `mvn -B test` (Maven toolchain not available in this environment)
- [x] CI workflow added to run `mvn -B test`

Made with [Cursor](https://cursor.com)