### PR TITLE
chore: add beta status disclaimer to Java README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Official Java SDK for Axme APIs and workflows.
 
 ## Status
 
-Beta parity kickoff in progress.
+Status: Beta (best-effort).
+API may change.
+For production use, prefer REST/OpenAPI or Python/TS SDKs.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- update the Java SDK status section with explicit beta best-effort messaging
- document API stability warning for beta phase
- direct production users to REST/OpenAPI or Python/TypeScript SDKs

## Test plan
- [x] docs-only change

Made with [Cursor](https://cursor.com)