### PR TITLE
feat: add intent runtime control APIs to Java SDK

### DIFF
--- a/src/main/java/dev/axme/sdk/AxmeClient.java
+++ b/src/main/java/dev/axme/sdk/AxmeClient.java
@@ -96,6 +96,69 @@ public final class AxmeClient {
         normalizeOptions(options));
   }
 
+  public Map<String, Object> createIntent(Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    return requestJson("POST", "/v1/intents", Map.of(), payload, normalizeOptions(options));
+  }
+
+  public Map<String, Object> getIntent(String intentId, RequestOptions options)
+      throws IOException, InterruptedException {
+    return requestJson("GET", "/v1/intents/" + intentId, Map.of(), null, normalizeOptions(options));
+  }
+
+  public Map<String, Object> listIntentEvents(String intentId, Integer since, RequestOptions options)
+      throws IOException, InterruptedException {
+    Map<String, String> query = new LinkedHashMap<>();
+    if (since != null && since >= 0) {
+      query.put("since", Integer.toString(since));
+    }
+    return requestJson("GET", "/v1/intents/" + intentId + "/events", query, null, normalizeOptions(options));
+  }
+
+  public Map<String, Object> resolveIntent(String intentId, Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    RequestOptions normalized = normalizeOptions(options);
+    return requestJson(
+        "POST",
+        "/v1/intents/" + intentId + "/resolve",
+        buildIntentControlQuery(normalized),
+        payload,
+        normalized);
+  }
+
+  public Map<String, Object> resumeIntent(String intentId, Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    RequestOptions normalized = normalizeOptions(options);
+    return requestJson(
+        "POST",
+        "/v1/intents/" + intentId + "/resume",
+        buildIntentControlQuery(normalized),
+        payload,
+        normalized);
+  }
+
+  public Map<String, Object> updateIntentControls(String intentId, Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    RequestOptions normalized = normalizeOptions(options);
+    return requestJson(
+        "POST",
+        "/v1/intents/" + intentId + "/controls",
+        buildIntentControlQuery(normalized),
+        payload,
+        normalized);
+  }
+
+  public Map<String, Object> updateIntentPolicy(String intentId, Map<String, Object> payload, RequestOptions options)
+      throws IOException, InterruptedException {
+    RequestOptions normalized = normalizeOptions(options);
+    return requestJson(
+        "POST",
+        "/v1/intents/" + intentId + "/policy",
+        buildIntentControlQuery(normalized),
+        payload,
+        normalized);
+  }
+
   private Map<String, Object> requestJson(
       String method,
       String path,
@@ -107,8 +170,10 @@ public final class AxmeClient {
         HttpRequest.newBuilder()
             .uri(URI.create(buildUrl(path, query)))
             .method(method, payload == null ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(payload)))
-            .header("Authorization", "Bearer " + apiKey)
             .header("Accept", "application/json");
+
+    String resolvedAuthorization = isBlank(options.getAuthorization()) ? "Bearer " + apiKey : options.getAuthorization();
+    builder.header("Authorization", resolvedAuthorization);
 
     if (payload != null) {
       builder.header("Content-Type", "application/json");
@@ -118,6 +183,9 @@ public final class AxmeClient {
     }
     if (!isBlank(options.getTraceId())) {
       builder.header("X-Trace-Id", options.getTraceId());
+    }
+    if (!isBlank(options.getXOwnerAgent())) {
+      builder.header("x-owner-agent", options.getXOwnerAgent());
     }
 
     HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
@@ -129,6 +197,14 @@ public final class AxmeClient {
     }
 
     return objectMapper.readValue(response.body(), new TypeReference<Map<String, Object>>() {});
+  }
+
+  private static Map<String, String> buildIntentControlQuery(RequestOptions options) {
+    Map<String, String> query = new LinkedHashMap<>();
+    if (!isBlank(options.getOwnerAgent())) {
+      query.put("owner_agent", options.getOwnerAgent());
+    }
+    return query;
   }
 
   private String buildUrl(String path, Map<String, String> query) {

--- a/src/main/java/dev/axme/sdk/RequestOptions.java
+++ b/src/main/java/dev/axme/sdk/RequestOptions.java
@@ -3,14 +3,29 @@ package dev.axme.sdk;
 public final class RequestOptions {
   private final String idempotencyKey;
   private final String traceId;
+  private final String ownerAgent;
+  private final String xOwnerAgent;
+  private final String authorization;
 
   public RequestOptions() {
-    this(null, null);
+    this(null, null, null, null, null);
   }
 
   public RequestOptions(String idempotencyKey, String traceId) {
+    this(idempotencyKey, traceId, null, null, null);
+  }
+
+  public RequestOptions(
+      String idempotencyKey,
+      String traceId,
+      String ownerAgent,
+      String xOwnerAgent,
+      String authorization) {
     this.idempotencyKey = idempotencyKey;
     this.traceId = traceId;
+    this.ownerAgent = ownerAgent;
+    this.xOwnerAgent = xOwnerAgent;
+    this.authorization = authorization;
   }
 
   public String getIdempotencyKey() {
@@ -19,6 +34,18 @@ public final class RequestOptions {
 
   public String getTraceId() {
     return traceId;
+  }
+
+  public String getOwnerAgent() {
+    return ownerAgent;
+  }
+
+  public String getXOwnerAgent() {
+    return xOwnerAgent;
+  }
+
+  public String getAuthorization() {
+    return authorization;
   }
 
   public static RequestOptions none() {

--- a/src/test/java/dev/axme/sdk/AxmeClientTest.java
+++ b/src/test/java/dev/axme/sdk/AxmeClientTest.java
@@ -142,4 +142,64 @@ class AxmeClientTest {
     assertEquals("/v1/service-accounts/sa_123/keys", server.takeRequest().getPath());
     assertEquals("/v1/service-accounts/sa_123/keys/sak_123/revoke", server.takeRequest().getPath());
   }
+
+  @Test
+  void intentLifecycleAndControlEndpointsAreReachable() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"intent_id\":\"it_123\"}"));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"intent\":{\"intent_id\":\"it_123\"}}"));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"events\":[]}"));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"applied\":false,\"policy_generation\":4}"));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"applied\":true}"));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"applied\":true,\"policy_generation\":5}"));
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"applied\":true,\"policy_generation\":6}"));
+
+    client.createIntent(
+        Map.of(
+            "intent_type", "notify.message.v1",
+            "from_agent", "agent://self",
+            "to_agent", "agent://target",
+            "payload", Map.of("text", "hello")),
+        RequestOptions.none());
+    assertEquals("/v1/intents", server.takeRequest().getPath());
+
+    client.getIntent("it_123", RequestOptions.none());
+    assertEquals("/v1/intents/it_123", server.takeRequest().getPath());
+
+    client.listIntentEvents("it_123", 2, RequestOptions.none());
+    assertEquals("/v1/intents/it_123/events?since=2", server.takeRequest().getPath());
+
+    client.resolveIntent(
+        "it_123",
+        Map.of("status", "COMPLETED", "expected_policy_generation", 3),
+        new RequestOptions(null, "trace-1", "agent://owner", "agent://owner", "Bearer scoped-token"));
+    RecordedRequest resolveRequest = server.takeRequest();
+    assertEquals("/v1/intents/it_123/resolve?owner_agent=agent%3A%2F%2Fowner", resolveRequest.getPath());
+    assertEquals("Bearer scoped-token", resolveRequest.getHeader("Authorization"));
+    assertEquals("agent://owner", resolveRequest.getHeader("x-owner-agent"));
+    assertEquals("trace-1", resolveRequest.getHeader("X-Trace-Id"));
+
+    client.resumeIntent(
+        "it_123",
+        Map.of("approve_current_step", true, "expected_policy_generation", 2),
+        new RequestOptions("resume-1", null, "agent://owner", null, null));
+    RecordedRequest resumeRequest = server.takeRequest();
+    assertEquals("/v1/intents/it_123/resume?owner_agent=agent%3A%2F%2Fowner", resumeRequest.getPath());
+    assertEquals("resume-1", resumeRequest.getHeader("Idempotency-Key"));
+
+    client.updateIntentControls(
+        "it_123",
+        Map.of("controls_patch", Map.of("timeout_seconds", 120), "expected_policy_generation", 5),
+        RequestOptions.none());
+    assertEquals("/v1/intents/it_123/controls", server.takeRequest().getPath());
+
+    client.updateIntentPolicy(
+        "it_123",
+        Map.of(
+            "grants_patch",
+            Map.of("delegate:agent://ops", Map.of("allow", new String[] {"resume", "update_controls"})),
+            "envelope_patch",
+            Map.of("max_retry_count", 10)),
+        new RequestOptions(null, null, "agent://creator", null, null));
+    assertEquals("/v1/intents/it_123/policy?owner_agent=agent%3A%2F%2Fcreator", server.takeRequest().getPath());
+  }
 }


### PR DESCRIPTION
## Summary
- add intent runtime control methods (`resume`, `controls`, `policy`) to Java client
- support scoped control auth options (`ownerAgent`, `xOwnerAgent`, custom authorization)
- add integration test coverage for new control endpoints

## Test plan
- [x] `mvn test`

Made with [Cursor](https://cursor.com)