### PR TITLE
release: configure Maven Central publishing for Java SDK

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -1,0 +1,38 @@
+name: publish-maven-central
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java and Maven Central credentials
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Verify build
+        run: mvn -B -ntp test
+
+      - name: Publish to Maven Central
+        run: mvn -B -ntp clean deploy -DskipTests

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Add to your `pom.xml`:
 
 ```xml
 <dependency>
-    <groupId>dev.axme</groupId>
-    <artifactId>axme-sdk</artifactId>
-    <version>0.1.0-alpha</version>
+    <groupId>ai.axme</groupId>
+    <artifactId>axme</artifactId>
+    <version>0.1.0</version>
 </dependency>
 ```
 
@@ -44,9 +44,6 @@ public class Quickstart {
         AxmeClient client = new AxmeClient(
             new AxmeClientConfig("https://gateway.axme.ai", "YOUR_API_KEY")
         );
-
-        // Check connectivity
-        System.out.println(client.health());
 
         // Send an intent
         Map<String, Object> intent = client.createIntent(
@@ -83,15 +80,19 @@ List endpoints return paginated results. The SDK handles cursor-based pagination
 *All list methods return a `cursor` field for the next page. Pass it as `after` in the next call. Filter and sort parameters are typed per endpoint.*
 
 ```java
-// Paginate through intents
-Map<String, Object> page = client.listIntents(
-    Map.of("status", "PENDING", "limit", 20),
+// Paginate through inbox changes
+Map<String, Object> page = client.listInboxChanges(
+    "agent://manager",
+    null,
+    50,
     RequestOptions.none()
 );
 
 while (page.get("cursor") != null) {
-    page = client.listIntents(
-        Map.of("after", page.get("cursor"), "limit", 20),
+    page = client.listInboxChanges(
+        "agent://manager",
+        (String) page.get("cursor"),
+        50,
         RequestOptions.none()
     );
 }
@@ -102,19 +103,40 @@ while (page.get("cursor") != null) {
 ## Approvals
 
 ```java
-Map<String, Object> inbox = client.listInbox(
-    Map.of("owner_agent", "agent://manager", "status", "PENDING"),
-    RequestOptions.none()
-);
+Map<String, Object> inbox = client.listInbox("agent://manager", RequestOptions.none());
 
 for (Object item : (List<?>) inbox.get("items")) {
     Map<?, ?> entry = (Map<?, ?>) item;
-    client.resolveApproval(
-        (String) entry.get("intent_id"),
-        Map.of("decision", "approved", "note", "Reviewed and approved"),
-        new RequestOptions(null, null)
+    Map<String, Object> action = (Map<String, Object>) entry.get("action");
+    if (action == null || action.get("approval_id") == null) {
+        continue;
+    }
+    client.decideApproval(
+        (String) action.get("approval_id"),
+        Map.of("decision", "approve", "reason", "Reviewed and approved"),
+        RequestOptions.none()
     );
 }
+```
+
+---
+
+## Intents
+
+```java
+Map<String, Object> created = client.createIntent(
+    Map.of(
+        "intent_type", "order.fulfillment.v1",
+        "owner_agent", "agent://fulfillment-service",
+        "payload", Map.of("order_id", "ord_123")
+    ),
+    new RequestOptions("intent-ord-123", null)
+);
+
+String intentId = (String) created.get("intent_id");
+
+Map<String, Object> current = client.getIntent(intentId, RequestOptions.none());
+Map<String, Object> events = client.listIntentEvents(intentId, null, RequestOptions.none());
 ```
 
 ---
@@ -133,11 +155,12 @@ Map<String, Object> sa = client.createServiceAccount(
 // Issue a key
 Map<String, Object> key = client.createServiceAccountKey(
     (String) sa.get("id"),
+    Map.of("name", "ci-key"),
     new RequestOptions(null, null)
 );
 
 // List service accounts
-client.listServiceAccounts("org_abc", RequestOptions.none());
+client.listServiceAccounts("org_abc", null, RequestOptions.none());
 
 // Revoke a key
 client.revokeServiceAccountKey(

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,36 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>dev.axme</groupId>
-  <artifactId>axme-sdk-java</artifactId>
+  <groupId>ai.axme</groupId>
+  <artifactId>axme</artifactId>
   <version>0.1.0</version>
-  <name>axme-sdk-java</name>
+  <name>Axme Java SDK</name>
   <description>Official Java SDK for Axme APIs and workflows.</description>
+  <url>https://github.com/AxmeAI/axme-sdk-java</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/license/mit</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>axmeai</id>
+      <name>AxmeAI</name>
+      <email>hello@axme.ai</email>
+      <organization>AxmeAI</organization>
+      <organizationUrl>https://axme.ai</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/AxmeAI/axme-sdk-java.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com:AxmeAI/axme-sdk-java.git</developerConnection>
+    <url>https://github.com/AxmeAI/axme-sdk-java</url>
+  </scm>
 
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
@@ -46,6 +71,68 @@
         <version>3.2.5</version>
         <configuration>
           <useModulePath>false</useModulePath>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>11</source>
+          <encoding>UTF-8</encoding>
+          <failOnError>false</failOnError>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.2.7</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Summary
- switch Java coordinates to `ai.axme:axme` and add Maven Central-required POM metadata
- add signing/source/javadoc/Central publishing plugins and a dedicated `publish-maven-central` GitHub Actions workflow
- align README dependency and quickstart snippets with the actual Java SDK methods

## Test plan
- [x] `mvn -B -ntp test`
- [x] `mvn -B -ntp clean verify` (local signing smoke)

Made with [Cursor](https://cursor.com)