### PR TITLE
fix: force Maven signing with primary key id

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -15,6 +15,7 @@ jobs:
       MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
       MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
               <goal>sign</goal>
             </goals>
             <configuration>
+              <keyname>${env.MAVEN_GPG_KEY_ID}!</keyname>
               <gpgArguments>
                 <arg>--pinentry-mode</arg>
                 <arg>loopback</arg>


### PR DESCRIPTION
## Summary
- force `maven-gpg-plugin` to sign with the primary key id (`MAVEN_GPG_KEY_ID!`)
- expose `MAVEN_GPG_KEY_ID` in publish workflow env so CI and local behavior match

## Test plan
- [x] `MAVEN_GPG_KEY_ID=... MAVEN_GPG_PASSPHRASE=... mvn -B -ntp clean verify`

Made with [Cursor](https://cursor.com)