### PR TITLE
feat: add cloud defaults and minimal Java quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ import java.util.Map;
 public class Quickstart {
     public static void main(String[] args) throws Exception {
         AxmeClient client = new AxmeClient(
-            new AxmeClientConfig(
-                "https://gateway.axme.ai",
-                "YOUR_PLATFORM_API_KEY", // sent as x-api-key
+            AxmeClientConfig.forCloud(
+                "AXME_API_KEY", // sent as x-api-key
                 "OPTIONAL_USER_OR_SESSION_TOKEN" // sent as Authorization: Bearer
             )
         );
+        // Optional override for staging/dev:
+        // AxmeClientConfig cfg = new AxmeClientConfig("https://staging-api.cloud.axme.ai", "AXME_API_KEY");
 
         // Check connectivity / discover available capabilities
         System.out.println(client.getCapabilities(RequestOptions.none()));
@@ -112,6 +113,26 @@ public class Quickstart {
     }
 }
 ```
+
+---
+
+## Minimal Language-Native Example
+
+Short basic submit/get example:
+
+- [`examples/BasicSubmit.java`](examples/BasicSubmit.java)
+
+Run (after SDK build/install):
+
+```bash
+export AXME_API_KEY="axme_sa_..."
+# compile/run according to your app setup, reusing examples/BasicSubmit.java
+```
+
+Full runnable scenario set lives in:
+
+- Cloud: <https://github.com/AxmeAI/axme-examples/tree/main/cloud>
+- Protocol-only: <https://github.com/AxmeAI/axme-examples/tree/main/protocol>
 
 ---
 
@@ -264,6 +285,8 @@ axme-sdk-java/
 │   │   ├── RequestOptions.java    # Idempotency key and correlation ID
 │   │   └── AxmeAPIException.java  # Typed exception
 │   └── test/                      # JUnit test suite
+├── examples/
+│   └── BasicSubmit.java           # Minimal language-native quickstart
 └── docs/
     └── diagrams/                  # Diagram copies for README embedding
 ```

--- a/examples/BasicSubmit.java
+++ b/examples/BasicSubmit.java
@@ -1,0 +1,41 @@
+import dev.axme.sdk.AxmeClient;
+import dev.axme.sdk.AxmeClientConfig;
+import dev.axme.sdk.RequestOptions;
+
+import java.util.Map;
+import java.util.UUID;
+
+public final class BasicSubmit {
+  public static void main(String[] args) throws Exception {
+    String apiKey = System.getenv("AXME_API_KEY");
+    String baseUrl = System.getenv("AXME_BASE_URL");
+    AxmeClientConfig config = (baseUrl == null || baseUrl.isBlank())
+        ? AxmeClientConfig.forCloud(apiKey)
+        : new AxmeClientConfig(baseUrl, apiKey);
+
+    AxmeClient client = new AxmeClient(config);
+    Map<String, Object> created = client.createIntent(
+        Map.of(
+            "intent_type", "intent.demo.v1",
+            "correlation_id", UUID.randomUUID().toString(),
+            "from_agent", "agent://basic/java/source",
+            "to_agent", "agent://basic/java/target",
+            "payload", Map.of("task", "hello-from-java")
+        ),
+        RequestOptions.none()
+    );
+    String intentId = (String) created.get("intent_id");
+    Map<String, Object> current = client.getIntent(intentId, RequestOptions.none());
+    Object intentObj = current.get("intent");
+    if (intentObj instanceof Map<?, ?> intentMap) {
+      Object status = intentMap.get("status");
+      if (status == null) {
+        status = intentMap.get("lifecycle_status");
+      }
+      System.out.println(status == null ? "UNKNOWN" : String.valueOf(status));
+      return;
+    }
+    Object status = current.get("status");
+    System.out.println(status == null ? "UNKNOWN" : String.valueOf(status));
+  }
+}

--- a/src/main/java/dev/axme/sdk/AxmeClientConfig.java
+++ b/src/main/java/dev/axme/sdk/AxmeClientConfig.java
@@ -1,9 +1,19 @@
 package dev.axme.sdk;
 
 public final class AxmeClientConfig {
+  public static final String DEFAULT_BASE_URL = "https://api.cloud.axme.ai";
+
   private final String baseUrl;
   private final String apiKey;
   private final String actorToken;
+
+  public static AxmeClientConfig forCloud(String apiKey) {
+    return new AxmeClientConfig(DEFAULT_BASE_URL, apiKey, null, null);
+  }
+
+  public static AxmeClientConfig forCloud(String apiKey, String actorToken) {
+    return new AxmeClientConfig(DEFAULT_BASE_URL, apiKey, actorToken, null);
+  }
 
   public AxmeClientConfig(String baseUrl, String apiKey) {
     this(baseUrl, apiKey, null, null);
@@ -14,9 +24,6 @@ public final class AxmeClientConfig {
   }
 
   public AxmeClientConfig(String baseUrl, String apiKey, String actorToken, String bearerToken) {
-    if (baseUrl == null || baseUrl.trim().isEmpty()) {
-      throw new IllegalArgumentException("baseUrl is required");
-    }
     if (apiKey == null || apiKey.trim().isEmpty()) {
       throw new IllegalArgumentException("apiKey is required");
     }
@@ -27,7 +34,8 @@ public final class AxmeClientConfig {
         && !normalizedActorToken.equals(normalizedBearerToken)) {
       throw new IllegalArgumentException("actorToken and bearerToken must match when both are provided");
     }
-    this.baseUrl = trimTrailingSlash(baseUrl.trim());
+    String normalizedBaseUrl = (baseUrl == null || baseUrl.trim().isEmpty()) ? DEFAULT_BASE_URL : baseUrl.trim();
+    this.baseUrl = trimTrailingSlash(normalizedBaseUrl);
     this.apiKey = apiKey.trim();
     this.actorToken = isNonBlank(normalizedActorToken) ? normalizedActorToken : normalizedBearerToken;
   }

--- a/src/test/java/dev/axme/sdk/AxmeClientTest.java
+++ b/src/test/java/dev/axme/sdk/AxmeClientTest.java
@@ -78,6 +78,12 @@ class AxmeClientTest {
   }
 
   @Test
+  void configUsesDefaultBaseUrlWhenBlank() {
+    AxmeClientConfig config = new AxmeClientConfig("", "platform-token");
+    assertEquals("https://api.cloud.axme.ai", config.getBaseUrl());
+  }
+
+  @Test
   void checkNickSendsQueryParameter() throws Exception {
     server.enqueue(
         new MockResponse()


### PR DESCRIPTION
## Summary
- add `AxmeClientConfig.forCloud(...)` helpers with AXME Cloud default base URL
- treat blank base URL as cloud default while keeping required API key validation
- add `examples/BasicSubmit.java` and README quickstart guidance linking to `axme-examples` for full runnable workflows

## Test plan
- [x] `mvn test` (containerized)
- [x] live run of `examples/BasicSubmit.java` with `AXME_API_KEY` against `https://api.cloud.axme.ai`

Made with [Cursor](https://cursor.com)