### PR TITLE
docs: update install example version to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then add to your `pom.xml`:
 <dependency>
     <groupId>ai.axme</groupId>
     <artifactId>axme</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
- Update README.md Maven dependency example from version `0.1.1` to `0.1.2` to match the current `pom.xml` version.

## Test plan
- [x] Verified `pom.xml` is at `0.1.2`
- [x] Verified `CHANGELOG.md` has `0.1.2` entry
- [x] Confirmed no other outdated version references in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)