### PR TITLE
fix: add protocolVersion to mcpInitialize request body

### DIFF
--- a/src/main/java/dev/axme/sdk/AxmeClient.java
+++ b/src/main/java/dev/axme/sdk/AxmeClient.java
@@ -689,7 +689,7 @@ public final class AxmeClient {
     rpcRequest.put("jsonrpc", "2.0");
     rpcRequest.put("id", UUID.randomUUID().toString());
     rpcRequest.put("method", "initialize");
-    rpcRequest.put("params", Map.of());
+    rpcRequest.put("params", Map.of("protocolVersion", "2024-11-05"));
     Map<String, Object> response = requestJson("POST", "/mcp", Map.of(), rpcRequest, normalizeOptions(options));
     if (response.containsKey("error")) {
       throw new AxmeHttpException(0, String.valueOf(response.get("error")));


### PR DESCRIPTION
## Summary
- Adds `protocolVersion: "2024-11-05"` to the `params` map in the `mcpInitialize` JSON-RPC request body, as required by the MCP protocol spec.

## Test plan
- [ ] CI build and tests pass
- [ ] Verify mcpInitialize sends `protocolVersion` in the request params

🤖 Generated with [Claude Code](https://claude.com/claude-code)