### PR TITLE
docs: add cross-org receive policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,30 @@ Map<String, Object> profile = client.getUserProfile(
 
 ---
 
+## Cross-Org Delivery Control
+
+Organizations can control which external orgs may send intents to their agents:
+
+1. **Org receive policy** — org-wide default (`open`, `allowlist`, `closed`)
+2. **Agent receive override** — per-agent exceptions to the org policy
+
+```java
+// Get org receive policy
+var policy = client.get("/v1/organizations/" + orgId + "/receive-policy");
+
+// Set to allowlist mode
+client.put("/v1/organizations/" + orgId + "/receive-policy",
+    Map.of("mode", "allowlist", "allowlist", List.of("org_id_of_trusted_partner")));
+
+// Per-agent override
+client.put("/v1/agents/" + address + "/receive-override",
+    Map.of("override_type", "allow", "source_org_id", "org_id_of_partner"));
+```
+
+See [`cross-org-receive-policy.md`](https://github.com/AxmeAI/axme-docs/blob/main/docs/cross-org-receive-policy.md) for the full decision flow.
+
+---
+
 ## MCP (Model Context Protocol)
 
 The Java SDK includes a built-in MCP endpoint client for gateway-hosted MCP sessions.


### PR DESCRIPTION
Add cross-org delivery control section documenting org receive policy and agent receive override APIs.