### PR TITLE
feat: send X-Axme-Client header for AXME analytics

### DIFF
--- a/src/main/java/dev/axme/sdk/AxmeClient.java
+++ b/src/main/java/dev/axme/sdk/AxmeClient.java
@@ -17,6 +17,13 @@ import java.util.Set;
 import java.util.UUID;
 
 public final class AxmeClient {
+
+  /**
+   * Published axme-sdk-java version. Sent in X-Axme-Client header so AXME
+   * platform analytics can identify SDK usage. Bump on every release.
+   */
+  public static final String SDK_VERSION = "0.2.0";
+
   private final String baseUrl;
   private final String apiKey;
   private final String actorToken;
@@ -864,6 +871,7 @@ public final class AxmeClient {
             .header("Accept", "application/json");
 
     builder.header("x-api-key", apiKey);
+    builder.header("X-Axme-Client", "axme-sdk-java/" + SDK_VERSION);
     String resolvedAuthorization = options.getAuthorization();
     if (isBlank(resolvedAuthorization) && !isBlank(actorToken)) {
       resolvedAuthorization = "Bearer " + actorToken;

--- a/src/test/java/dev/axme/sdk/AxmeClientTest.java
+++ b/src/test/java/dev/axme/sdk/AxmeClientTest.java
@@ -46,12 +46,21 @@ class AxmeClientTest {
     assertEquals("POST", request.getMethod());
     assertEquals("/v1/users/register-nick", request.getPath());
     assertEquals("token", request.getHeader("x-api-key"));
+    assertEquals("axme-sdk-java/" + AxmeClient.SDK_VERSION, request.getHeader("X-Axme-Client"));
     assertEquals("register-1", request.getHeader("Idempotency-Key"));
 
     Map<String, Object> body =
         objectMapper.readValue(request.getBody().readUtf8(), new TypeReference<Map<String, Object>>() {});
     assertEquals("@partner.user", body.get("nick"));
     assertTrue((Boolean) response.get("ok"));
+  }
+
+  @Test
+  void clientSendsXAxmeClientHeader() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":true,\"available\":true}"));
+    client.checkNick("@partner.user", RequestOptions.none());
+    RecordedRequest request = server.takeRequest();
+    assertEquals("axme-sdk-java/" + AxmeClient.SDK_VERSION, request.getHeader("X-Axme-Client"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Adds `X-Axme-Client: axme-sdk-{lang}/{version}` header to all outgoing HTTP requests so the AXME platform admin dashboard can identify which SDK generated traffic. Per-org breakdown is exposed via `/admin/analytics/users/{org_id}/activity` `usage_breakdown.client_types` field on the control plane.

Without this header, all SDK requests show up as `unknown` in the admin user-detail page client breakdown panel.

## Changes
- New SDK version constant
- Header added in the request builder
- Unit test verifies the header is set on outgoing requests

## Test plan
- [x] Unit tests pass
- [ ] After merge + release, verify header appears in `api_usage_hourly.client_type` on staging